### PR TITLE
Host LightenDiffusion on Hugging Face

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ LSRW dataset: Jiang Hai, Zhu Xuan, Ren Yang, Yutong Hao, Fengzhu Zou, Fang Lin, 
 Please refer to [[Project Page of RetinexNet]](https://daooshee.github.io/BMVC2018website/).
 
 ## Pre-trained Models 
-You can download our pre-trained model from [[Google Drive]](https://drive.google.com/drive/folders/1m3t15rWw76IDDWJ0exLOe5P0uEnjk3zl?usp=drive_link) and [[Baidu Yun (extracted code:cjzk)]](https://pan.baidu.com/s/1fPLVgnZbdY1n75Flq54bMQ)
+You can download our pre-trained model from [Hugging Face](...).
+
+Alternatively, the model is also available on [[Google Drive]](https://drive.google.com/drive/folders/1m3t15rWw76IDDWJ0exLOe5P0uEnjk3zl?usp=drive_link) and [[Baidu Yun (extracted code:cjzk)]](https://pan.baidu.com/s/1fPLVgnZbdY1n75Flq54bMQ)
 
 ## How to train?
 You need to modify ```datasets/dataset.py``` slightly for your environment, and then


### PR DESCRIPTION
Hello @JianghaiSCU 🤗 

I'm Niels and work as part of the open-source team at Hugging Face. I discovered through ECCV (congrats!) and indexed the paper page here: https://huggingface.co/papers/2407.08939. The paper page lets people discuss about your paper and lets them find artifacts about it (your model for instance) you can also claim the paper as yours which will show up on your public profile at HF.

Would you like to host the model you've pre-trained on https://huggingface.co/models, rather than Google Drive? Hosting on Hugging Face will give you more visibility. We can add tags in the model cards so that people find the models easier, link it to the paper page, etc.

If you're down, leaving a guide [here](https://huggingface.co/docs/hub/models-uploading). If it's a PyTorch model, you can use [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which adds from_pretrained and push_to_hub to the model which lets you to upload the model and people to download and use models right away.
If you do not want this and directly want to upload model through UI or however you want, people can also use [hf_hub_download](https://huggingface.co/docs/huggingface_hub/en/guides/download#download-a-single-file).

After uploaded, we can also link the models to the paper page (read [here](https://huggingface.co/docs/hub/en/model-cards#linking-a-paper)) so people can discover your model.

You can also build a demo to your model on [Spaces](https://huggingface.co/spaces) we can provide you an A100 grant.

What do you think?